### PR TITLE
add CStyleForLoop lint rule

### DIFF
--- a/cli/main.mbt
+++ b/cli/main.mbt
@@ -75,6 +75,19 @@ fn message_for_warning(warning : @moonlint.Warning) -> String {
         replace_condition~,
       )
     }
+    CStyleForLoop(loc) => {
+      let antipattern =
+        #|     for i = 0; i < items.length(); i = i + 1 {
+        #|       ... items[i] ...
+        #|     }
+      let suggestion =
+        #|rewrite to:
+        #|
+        #|     for item in items {
+        #|       ... item ...
+        #|     }
+      return report_antipattern(loc~, antipattern~, suggestion~)
+    }
   }
 }
 

--- a/cli/pkg.generated.mbti
+++ b/cli/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "myfreess/moonlint/cli"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/pkg.generated.mbti
+++ b/pkg.generated.mbti
@@ -1,0 +1,26 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "myfreess/moonlint"
+
+import(
+  "moonbitlang/core/list"
+  "moonbitlang/parser/basic"
+  "moonbitlang/parser/syntax"
+)
+
+// Values
+pub fn lint(@list.List[@syntax.Impl]) -> Array[Warning]
+
+// Errors
+
+// Types and methods
+pub enum Warning {
+  MatchTryQuestion(@basic.Location)
+  StringLiteralMultiplyNumber(@basic.Location)
+  CStyleForLoop(@basic.Location)
+}
+pub impl Show for Warning
+
+// Type aliases
+
+// Traits
+

--- a/warnings.mbt
+++ b/warnings.mbt
@@ -2,10 +2,91 @@
 pub enum Warning {
   MatchTryQuestion(Location)
   StringLiteralMultiplyNumber(Location)
+  CStyleForLoop(Location)
 } derive(Show)
 
 ///|
 priv struct LintEnv(Array[Warning])
+
+///|
+/// Check if the variable is only used in array[var] form,
+/// and extract the array name
+priv struct ArrayGetChecker {
+  var_name : String
+  mut array_name : String?
+  mut is_valid : Bool
+}
+
+///|
+impl @syntax.IterVisitor for ArrayGetChecker with visit_Expr(self, expr) {
+  match expr {
+    ArrayGet(array=Ident(id={ name: Ident(name~), .. }, ..), index=Ident(id=idx, ..), ..) => {
+      if idx.name is Ident(name=idx_name) && idx_name == self.var_name {
+        // Found items[i] pattern
+        match self.array_name {
+          None => self.array_name = Some(name)
+          Some(existing) =>
+            if existing != name {
+              // Different arrays used, not a simple iteration
+              self.is_valid = false
+            }
+        }
+        // Don't visit children - we've handled this usage
+        return
+      }
+    }
+    Ident(id={ name: Ident(name~), .. }, ..) => {
+      if name == self.var_name {
+        // Variable used outside of array indexing
+        self.is_valid = false
+      }
+    }
+    _ => ()
+  }
+  self.base().visit_Expr(expr)
+}
+
+///|
+fn check_only_array_get_usage(
+  var_name : String,
+  expr : @syntax.Expr
+) -> String? {
+  let checker = ArrayGetChecker::{ var_name, array_name: None, is_valid: true }
+  checker.visit_Expr(expr)
+  if checker.is_valid {
+    checker.array_name
+  } else {
+    None
+  }
+}
+
+///|
+/// Check if the condition is in the form `i < array.length()` or `i < array.count()`
+fn extract_array_from_condition(
+  var_name : String,
+  cond : @syntax.Expr
+) -> String? {
+  match cond {
+    Infix(
+      op={ name: Ident(name="<"), .. },
+      lhs=Ident(id={ name: Ident(name~), .. }, ..),
+      rhs=DotApply(
+        self=Ident(id={ name: Ident(name=array_name), .. }, ..),
+        method_name={ name: method_name, .. },
+        args=Empty,
+        ..
+      ),
+      ..
+    ) => {
+      if name == var_name && (method_name == "length" || method_name == "count") {
+        Some(array_name)
+      } else {
+        None
+      }
+    }
+    _ => None
+  }
+}
 
 ///|
 impl @syntax.IterVisitor for LintEnv with visit_Expr(env, expr) {
@@ -59,6 +140,32 @@ impl @syntax.IterVisitor for LintEnv with visit_Expr(env, expr) {
     /// "<string literal>".repeat(n)
     /// ```
     env.0.push(Warning::StringLiteralMultiplyNumber(loc))
+  }
+  // Check for C-style for loop that could be foreach
+  // Pattern: for i = 0; i < items.length(); i = i + 1 { items[i] }
+  if expr
+    is For(
+      binders=More((binder, Constant(c=Int(init_val), ..)), tail=Empty),
+      condition=Some(condition),
+      continue_block=More((cont_binder, _), tail=Empty),
+      body~,
+      loc~,
+      ..
+    ) {
+    let var_name = binder.name
+    // Check: init value is 0, and continue_block uses same variable
+    if init_val == "0" && cont_binder.name == var_name {
+      // Check if condition is `i < items.length()`
+      if extract_array_from_condition(var_name, condition) is Some(cond_array) {
+        // Check if variable is only used in items[i] form in the body
+        if check_only_array_get_usage(var_name, body) is Some(body_array) {
+          // Check if both reference the same array
+          if cond_array == body_array {
+            env.0.push(Warning::CStyleForLoop(loc))
+          }
+        }
+      }
+    }
   }
   env.base().visit_Expr(expr)
 }

--- a/warnings.mbt
+++ b/warnings.mbt
@@ -20,7 +20,11 @@ priv struct ArrayGetChecker {
 ///|
 impl @syntax.IterVisitor for ArrayGetChecker with visit_Expr(self, expr) {
   match expr {
-    ArrayGet(array=Ident(id={ name: Ident(name~), .. }, ..), index=Ident(id=idx, ..), ..) => {
+    ArrayGet(
+      array=Ident(id={ name: Ident(name~), .. }, ..),
+      index=Ident(id=idx, ..),
+      ..
+    ) =>
       if idx.name is Ident(name=idx_name) && idx_name == self.var_name {
         // Found items[i] pattern
         match self.array_name {
@@ -34,13 +38,11 @@ impl @syntax.IterVisitor for ArrayGetChecker with visit_Expr(self, expr) {
         // Don't visit children - we've handled this usage
         return
       }
-    }
-    Ident(id={ name: Ident(name~), .. }, ..) => {
+    Ident(id={ name: Ident(name~), .. }, ..) =>
       if name == self.var_name {
         // Variable used outside of array indexing
         self.is_valid = false
       }
-    }
     _ => ()
   }
   self.base().visit_Expr(expr)
@@ -49,7 +51,7 @@ impl @syntax.IterVisitor for ArrayGetChecker with visit_Expr(self, expr) {
 ///|
 fn check_only_array_get_usage(
   var_name : String,
-  expr : @syntax.Expr
+  expr : @syntax.Expr,
 ) -> String? {
   let checker = ArrayGetChecker::{ var_name, array_name: None, is_valid: true }
   checker.visit_Expr(expr)
@@ -64,7 +66,7 @@ fn check_only_array_get_usage(
 /// Check if the condition is in the form `i < array.length()` or `i < array.count()`
 fn extract_array_from_condition(
   var_name : String,
-  cond : @syntax.Expr
+  cond : @syntax.Expr,
 ) -> String? {
   match cond {
     Infix(
@@ -77,13 +79,12 @@ fn extract_array_from_condition(
         ..
       ),
       ..
-    ) => {
+    ) =>
       if name == var_name && (method_name == "length" || method_name == "count") {
         Some(array_name)
       } else {
         None
       }
-    }
     _ => None
   }
 }

--- a/warnings_test.mbt
+++ b/warnings_test.mbt
@@ -57,10 +57,7 @@ let c_style_for_loop =
 ///|
 test "c style for loop" {
   let warnings = test_lint(c_style_for_loop)
-  inspect(
-    warnings,
-    content="[CStyleForLoop(<lint test>-3:3-5:4)]",
-  )
+  inspect(warnings, content="[CStyleForLoop(<lint test>-3:3-5:4)]")
 }
 
 ///|

--- a/warnings_test.mbt
+++ b/warnings_test.mbt
@@ -44,3 +44,56 @@ test "string literal multiply number" {
     content="[StringLiteralMultiplyNumber(<lint test>-2:11-2:22)]",
   )
 }
+
+///|
+let c_style_for_loop =
+  #|fn main {
+  #|  let items = [1, 2, 3]
+  #|  for i = 0; i < items.length(); i = i + 1 {
+  #|    println(items[i])
+  #|  }
+  #|}
+
+///|
+test "c style for loop" {
+  let warnings = test_lint(c_style_for_loop)
+  inspect(
+    warnings,
+    content="[CStyleForLoop(<lint test>-3:3-5:4)]",
+  )
+}
+
+///|
+let c_style_for_loop_ok =
+  #|fn main {
+  #|  let items = [1, 2, 3]
+  #|  for i = 0; i < items.length(); i = i + 1 {
+  #|    // i is used for something else too
+  #|    println(items[i])
+  #|    println(i)
+  #|  }
+  #|}
+
+///|
+test "c style for loop ok - multiple usages" {
+  let warnings = test_lint(c_style_for_loop_ok)
+  inspect(warnings, content="[]")
+}
+
+///|
+let c_style_for_loop_ok_different_array =
+  #|fn main {
+  #|  let items = [1, 2, 3]
+  #|  let other = [4, 5, 6]
+  #|  for i = 0; i < items.length(); i = i + 1 {
+  #|    // i is used with different arrays
+  #|    println(items[i])
+  #|    println(other[i])
+  #|  }
+  #|}
+
+///|
+test "c style for loop ok - different arrays" {
+  let warnings = test_lint(c_style_for_loop_ok_different_array)
+  inspect(warnings, content="[]")
+}


### PR DESCRIPTION
## Summary
- Add new lint rule `CStyleForLoop` that detects C-style for loops that can be simplified to foreach
- Detects pattern: `for i = 0; i < items.length(); i = i + 1 { ... items[i] ... }`
- Suggests rewriting to: `for item in items { ... item ... }`

## Details
The rule triggers when:
- Loop initializes with `i = 0`
- Condition is `i < array.length()` or `i < array.count()`
- Loop variable is only used in `array[i]` form within the body
- Both condition and body reference the same array

## Test plan
- [x] Added test for detection case
- [x] Added test for non-detection when `i` is used elsewhere (e.g., `println(i)`)
- [x] Added test for non-detection when `i` indexes different arrays

🤖 Generated with [Claude Code](https://claude.com/claude-code)