### PR TITLE
add ConsecutivePrintln lint rule

### DIFF
--- a/cli/main.mbt
+++ b/cli/main.mbt
@@ -88,6 +88,21 @@ fn message_for_warning(warning : @moonlint.Warning) -> String {
         #|     }
       return report_antipattern(loc~, antipattern~, suggestion~)
     }
+    ConsecutivePrintln(loc) => {
+      let antipattern =
+        #|     println("line 1")
+        #|     println("line 2")
+        #|     println("line 3")
+      let suggestion =
+        #|rewrite to:
+        #|
+        #|     let msg =
+        #|       #|line 1
+        #|       #|line 2
+        #|       #|line 3
+        #|     println(msg)
+      return report_antipattern(loc~, antipattern~, suggestion~)
+    }
   }
 }
 

--- a/pkg.generated.mbti
+++ b/pkg.generated.mbti
@@ -17,6 +17,7 @@ pub enum Warning {
   MatchTryQuestion(@basic.Location)
   StringLiteralMultiplyNumber(@basic.Location)
   CStyleForLoop(@basic.Location)
+  ConsecutivePrintln(@basic.Location)
 }
 pub impl Show for Warning
 

--- a/warnings.mbt
+++ b/warnings.mbt
@@ -3,6 +3,7 @@ pub enum Warning {
   MatchTryQuestion(Location)
   StringLiteralMultiplyNumber(Location)
   CStyleForLoop(Location)
+  ConsecutivePrintln(Location)
 } derive(Show)
 
 ///|
@@ -90,6 +91,152 @@ fn extract_array_from_condition(
 }
 
 ///|
+/// Check if an expression is `println("<string literal>")` and return its location
+fn is_println_string_literal(expr : @syntax.Expr) -> Location? {
+  match expr {
+    Apply(
+      func=Ident(id={ name: Ident(name="println"), .. }, ..),
+      args=More(
+        { value: Constant(c=String(_), ..), kind: Positional },
+        tail=Empty
+      ),
+      loc~,
+      ..
+    ) => Some(loc)
+    _ => None
+  }
+}
+
+///|
+/// Find consecutive println string literal calls (3 or more)
+/// Returns the location of the first println in the consecutive sequence, or None
+fn find_consecutive_println(exprs : @list.List[@syntax.Expr]) -> Location? {
+  find_consecutive_println_helper(exprs, None, 0)
+}
+
+///|
+fn find_consecutive_println_helper(
+  exprs : @list.List[@syntax.Expr],
+  first_loc : Location?,
+  count : Int,
+) -> Location? {
+  match exprs {
+    More(expr, tail~) =>
+      match is_println_string_literal(expr) {
+        Some(loc) => {
+          let new_first_loc = if first_loc is None {
+            Some(loc)
+          } else {
+            first_loc
+          }
+          let new_count = count + 1
+          if new_count >= 3 {
+            // Found 3+ consecutive printlns, return the first location
+            new_first_loc
+          } else {
+            find_consecutive_println_helper(tail, new_first_loc, new_count)
+          }
+        }
+        None =>
+          // Reset and continue searching
+          find_consecutive_println_helper(tail, None, 0)
+      }
+    Empty =>
+      // Reached end, check if we had 3+ consecutive
+      if count >= 3 {
+        first_loc
+      } else {
+        None
+      }
+  }
+}
+
+///|
+/// Check trailing println including last_expr
+fn check_trailing_println(
+  env : LintEnv,
+  exprs : @list.List[@syntax.Expr],
+  last_expr : @syntax.Expr,
+) -> Unit {
+  // Only check if last_expr is a println
+  if is_println_string_literal(last_expr) is None {
+    return
+  }
+  // Count consecutive println from the end of exprs
+  let count = count_trailing_println(exprs)
+  // If we have 2+ trailing println in exprs + 1 from last_expr = 3+
+  if count >= 2 {
+    // Get the location of the first println in the trailing sequence
+    if get_nth_from_end_println_loc(exprs, count) is Some(loc) {
+      env.0.push(Warning::ConsecutivePrintln(loc))
+    }
+  }
+}
+
+///|
+/// Count consecutive println from the end of the list
+fn count_trailing_println(exprs : @list.List[@syntax.Expr]) -> Int {
+  count_trailing_println_helper(exprs, 0)
+}
+
+///|
+fn count_trailing_println_helper(
+  exprs : @list.List[@syntax.Expr],
+  acc : Int,
+) -> Int {
+  match exprs {
+    More(expr, tail~) => {
+      let tail_count = count_trailing_println_helper(tail, acc)
+      // If we're at the end and all following are println, check this one
+      if tail_count == list_length(tail) {
+        if is_println_string_literal(expr) is Some(_) {
+          tail_count + 1
+        } else {
+          0
+        }
+      } else {
+        tail_count
+      }
+    }
+    Empty => 0
+  }
+}
+
+///|
+fn list_length(exprs : @list.List[@syntax.Expr]) -> Int {
+  match exprs {
+    More(_, tail~) => 1 + list_length(tail)
+    Empty => 0
+  }
+}
+
+///|
+/// Get the location of the Nth println from the end
+fn get_nth_from_end_println_loc(
+  exprs : @list.List[@syntax.Expr],
+  n : Int,
+) -> Location? {
+  let len = list_length(exprs)
+  get_nth_println_loc(exprs, len - n)
+}
+
+///|
+fn get_nth_println_loc(
+  exprs : @list.List[@syntax.Expr],
+  index : Int,
+) -> Location? {
+  match exprs {
+    More(expr, tail~) =>
+      if index == 0 {
+        is_println_string_literal(expr)
+      } else {
+        get_nth_println_loc(tail, index - 1)
+      }
+    Empty => None
+  }
+}
+
+///|
 impl @syntax.IterVisitor for LintEnv with visit_Expr(env, expr) {
   if expr
     is Match(
@@ -166,6 +313,18 @@ impl @syntax.IterVisitor for LintEnv with visit_Expr(env, expr) {
           }
         }
       }
+    }
+  }
+  // Check for consecutive println string literals (3 or more)
+  // Pattern: println("..."); println("..."); println("...")
+  if expr is Sequence(exprs~, last_expr~, ..) {
+    // Check the exprs list
+    match find_consecutive_println(exprs) {
+      Some(loc) => env.0.push(Warning::ConsecutivePrintln(loc))
+      None =>
+        // Only check trailing if we didn't find 3+ consecutive in exprs
+        // This handles the case: println; println; <last_expr=println>
+        check_trailing_println(env, exprs, last_expr)
     }
   }
   env.base().visit_Expr(expr)

--- a/warnings_test.mbt
+++ b/warnings_test.mbt
@@ -94,3 +94,105 @@ test "c style for loop ok - different arrays" {
   let warnings = test_lint(c_style_for_loop_ok_different_array)
   inspect(warnings, content="[]")
 }
+
+///|
+let consecutive_println =
+  #|fn main {
+  #|  println("line 1")
+  #|  println("line 2")
+  #|  println("line 3")
+  #|}
+
+///|
+test "consecutive println" {
+  let warnings = test_lint(consecutive_println)
+  inspect(warnings, content="[ConsecutivePrintln(<lint test>-2:3-2:20)]")
+}
+
+///|
+let consecutive_println_four =
+  #|fn main {
+  #|  println("line 1")
+  #|  println("line 2")
+  #|  println("line 3")
+  #|  println("line 4")
+  #|}
+
+///|
+test "consecutive println - four lines" {
+  let warnings = test_lint(consecutive_println_four)
+  inspect(warnings, content="[ConsecutivePrintln(<lint test>-2:3-2:20)]")
+}
+
+///|
+let consecutive_println_ok_two =
+  #|fn main {
+  #|  println("line 1")
+  #|  println("line 2")
+  #|}
+
+///|
+test "consecutive println ok - two lines" {
+  let warnings = test_lint(consecutive_println_ok_two)
+  inspect(warnings, content="[]")
+}
+
+///|
+let consecutive_println_ok_interrupted =
+  #|fn main {
+  #|  println("line 1")
+  #|  println("line 2")
+  #|  let x = 1
+  #|  println("line 3")
+  #|}
+
+///|
+test "consecutive println ok - interrupted" {
+  let warnings = test_lint(consecutive_println_ok_interrupted)
+  inspect(warnings, content="[]")
+}
+
+///|
+let consecutive_println_with_variable =
+  #|fn main {
+  #|  let x = 1
+  #|  println("line 1")
+  #|  println("line 2")
+  #|  println(x.to_string())
+  #|}
+
+///|
+test "consecutive println ok - with variable" {
+  let warnings = test_lint(consecutive_println_with_variable)
+  inspect(warnings, content="[]")
+}
+
+///|
+let consecutive_println_as_last_expr =
+  #|fn main {
+  #|  let x = 1
+  #|  println("line 1")
+  #|  println("line 2")
+  #|  println("line 3")
+  #|}
+
+///|
+test "consecutive println - as last expr" {
+  let warnings = test_lint(consecutive_println_as_last_expr)
+  inspect(warnings, content="[ConsecutivePrintln(<lint test>-3:3-3:20)]")
+}
+
+///|
+let consecutive_println_ok_with_interp =
+  #|fn main {
+  #|  let x = 1
+  #|  println("line 1")
+  #|  println("line \{x}")
+  #|  println("line 3")
+  #|}
+
+///|
+test "consecutive println ok - with interpolation" {
+  let warnings = test_lint(consecutive_println_ok_with_interp)
+  inspect(warnings, content="[]")
+}


### PR DESCRIPTION
## Summary

- Current LLMs often cannot predict `#|` multiline string literals, so they tend to write consecutive `println("...")` calls instead
- This lint rule detects 3 or more consecutive `println` with string literals and suggests using multiline string with `let` binding
- `println` with string interpolation (`\{}`) is excluded since it cannot be replaced with multiline literals

## Example

**Anti-pattern (detected):**
```moonbit
println("line 1")
println("line 2")
println("line 3")
```

**Suggestion:**
```moonbit
let msg =
  #|line 1
  #|line 2
  #|line 3
println(msg)
```

## Test plan

- [x] Added test cases for detection (3+ consecutive println)
- [x] Added test cases for non-detection (2 consecutive, interrupted, with interpolation)
- [x] All tests pass (`moon test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)